### PR TITLE
Remove needless Empty.h

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,6 @@
 #include <Wire.h>
 #include <concaveteam/Spherical.h>
 #include <concaveteam/Trigger.h>
-#include <std_msgs/Empty.h>
 #include <std_srvs/Empty.h>
 #include <ros.h>
 


### PR DESCRIPTION
When the gun is to be triggered, there is a call and response. However, no data is necessarily exchanged. All we have to know is that we need to pull the trigger, nothing more. Therefore, the triggering service responds to an `std_srvs::Empty` type and sends back another `std_srvs::Empty` once it is done.

The reason I am undoing the include for `std_msgs/Empty.h` is because services and messages are different in ROS, and in this case we are using a service and only need `std_srvs/Empty.h`.